### PR TITLE
DocComment for the main class is incorrect when an anonymous class is used inside.

### DIFF
--- a/tests/Doctrine/Tests/Common/Reflection/AnnotationClassWithAnonymousClass.php
+++ b/tests/Doctrine/Tests/Common/Reflection/AnnotationClassWithAnonymousClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Tests\Common\Reflection;
+
+use Doctrine\Common\Annotations\Annotation;
+use stdClass;
+
+/**
+ * @Annotation(
+ *   key = "value"
+ * )
+ */
+class AnnotationClassWithAnonymousClass
+{
+    public function foo() {
+
+        $new_class = new class () {};
+
+    }
+}

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -110,6 +110,8 @@ class StaticReflectionParserTest extends DoctrineTestCase
             [ExampleAnnotationClass::class, true],
             [AnnotationClassWithScopeResolution::class, false],
             [AnnotationClassWithScopeResolution::class, true],
+            [AnnotationClassWithAnonymousClass::class, false],
+            [AnnotationClassWithAnonymousClass::class, true],
         ];
     }
 }


### PR DESCRIPTION
Pull request with a test scenario for #19.