### PR TITLE
Add reflection typed no default property class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Doctrine\\Tests\\": "tests/Doctrine/Tests"
+            "Doctrine\\Tests\\": "tests/Doctrine/Tests",
+            "Doctrine\\Tests_PHP74\\": "tests/Doctrine/Tests_PHP74"
         }
     },
     "extra": {

--- a/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
@@ -18,6 +18,6 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
      */
     public function getValue($object = null)
     {
-        return isset($object->{$this->getName()}) ? parent::getValue($object) : null;
+        return isset($object->{$this->name}) ? parent::getValue($object) : null;
     }
 }

--- a/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
@@ -18,8 +18,6 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
      */
     public function getValue($object = null)
     {
-        $name = $this->getName();
-
-        return isset($object->$name) ? parent::getValue($object) : null;
+        return isset($object->{$this->getName()}) ? parent::getValue($object) : null;
     }
 }

--- a/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Common\Reflection;
+
+use ReflectionProperty;
+
+/**
+ * PHP Typed No Default Reflection Property - special override for typed properties without a default value.
+ */
+class TypedNoDefaultReflectionProperty extends ReflectionProperty
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Checks that a typed property is initialized before accessing its value.
+     * This is neccessary to avoid PHP error "Error: Typed property must not be accessed before initialization".
+     * Should be used only for reflecting typed properties without a default value.
+     */
+    public function getValue($object = null)
+    {
+        $name = $this->getName();
+
+        return isset($object->$name) ? parent::getValue($object) : null;
+    }
+}

--- a/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
@@ -18,6 +18,6 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
      */
     public function getValue($object = null)
     {
-        return isset($object->{$this->name}) ? parent::getValue($object) : null;
+        return $object !== null && $this->isInitialized($object) ? parent::getValue($object) : null;
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,8 @@
 >
     <testsuites>
         <testsuite name="Doctrine Event Manager Test Suite">
-            <directory>./tests/Doctrine/</directory>
+            <directory>./tests/Doctrine/Tests</directory>
+            <directory phpVersion="7.4" phpVersionOperator=">=">./tests/Doctrine/Tests_PHP74</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
@@ -13,7 +13,7 @@ class TypedNoDefaultReflectionPropertyTest extends TestCase
 
         $reflProperty = new TypedNoDefaultReflectionProperty(TypedNoDefaultReflectionPropertyTestClass::class, 'test');
 
-        self::assertSame(null, $reflProperty->getValue($object));
+        self::assertNull($reflProperty->getValue($object));
 
         $object->test = 'testValue';
 

--- a/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\Tests_PHP74\Common\Reflection;
+
+use Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty;
+use PHPUnit\Framework\TestCase;
+
+class TypedNoDefaultReflectionPropertyTest extends TestCase
+{
+    public function testGetValue() : void
+    {
+        $object = new TypedNoDefaultReflectionPropertyTestClass();
+
+        $reflProperty = new TypedNoDefaultReflectionProperty(TypedNoDefaultReflectionPropertyTestClass::class, 'test');
+
+        self::assertSame(null, $reflProperty->getValue($object));
+
+        $object->test = 'testValue';
+
+        self::assertSame('testValue', $reflProperty->getValue($object));
+
+        unset($object->test);
+
+        self::assertNull($reflProperty->getValue($object));
+    }
+}
+
+class TypedNoDefaultReflectionPropertyTestClass
+{
+    public string $test;
+}


### PR DESCRIPTION
Implementation for issue https://github.com/doctrine/reflection/issues/23
See discussion in https://github.com/doctrine/orm/pull/7857

As suggested by @beberlei, the `\Doctrine\Common\Reflection\TypedNoDefaultReflectionProperty` class was introduced.
It will be returned in `doctrine/persistence` package class [RuntimeReflectionService::getAccessibleProperty](https://github.com/doctrine/persistence/blob/master/lib/Doctrine/Persistence/Mapping/RuntimeReflectionService.php) if the property is typed and has no default value. Something like this:
```php
/**
 * {@inheritDoc}
 */
public function getAccessibleProperty(string $class, string $property) : ?ReflectionProperty
{
    $reflectionProperty = new ReflectionProperty($class, $property);

    if (! array_key_exists($property, $this->getClass($class)->getDefaultProperties())) {
        $reflectionProperty = new TypedNoDefaultReflectionProperty($class, $property);
    } elseif ($reflectionProperty->isPublic()) {
        $reflectionProperty = new RuntimePublicReflectionProperty($class, $property);
    }

    $reflectionProperty->setAccessible(true);

    return $reflectionProperty;
}
```

Also updated phpunit config as suggested in the discussion in the same issue https://github.com/doctrine/reflection/issues/23.
This allows skipping tests containing php 7.4 specific syntax on builds with lesser php versions.
Also updated `travis-ci.yml` Lint job to ignore such tests by phpstan analysis, if the php version is less than 7.4