### PR TITLE
Fix reading docblocks for classes containing anonymous classes

### DIFF
--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -8,6 +8,7 @@ use const T_CLASS;
 use const T_DOC_COMMENT;
 use const T_EXTENDS;
 use const T_FUNCTION;
+use const T_NEW;
 use const T_PAAMAYIM_NEKUDOTAYIM;
 use const T_PRIVATE;
 use const T_PROTECTED;
@@ -161,7 +162,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
                     $docComment = $token[1];
                     break;
                 case T_CLASS:
-                    if ($last_token !== T_PAAMAYIM_NEKUDOTAYIM) {
+                    if ($last_token !== T_PAAMAYIM_NEKUDOTAYIM && $last_token !== T_NEW) {
                         $this->docComment['class'] = $docComment;
                         $docComment                = '';
                     }

--- a/tests/Doctrine/Tests/Common/Reflection/AnnotationClassWithAnonymousClass.php
+++ b/tests/Doctrine/Tests/Common/Reflection/AnnotationClassWithAnonymousClass.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Common\Reflection;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation(
+ *   key = "value"
+ * )
+ */
+class AnnotationClassWithAnonymousClass
+{
+    public function foo()
+    {
+        $new_class = new class () {
+        };
+    }
+}

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -110,6 +110,8 @@ class StaticReflectionParserTest extends DoctrineTestCase
             [ExampleAnnotationClass::class, true],
             [AnnotationClassWithScopeResolution::class, false],
             [AnnotationClassWithScopeResolution::class, true],
+            [AnnotationClassWithAnonymousClass::class, false],
+            [AnnotationClassWithAnonymousClass::class, true],
         ];
     }
 }


### PR DESCRIPTION
Fixes #19.
The tests were taken from https://github.com/doctrine/reflection/pull/20 by @xopoc14

I'm not shure that it's correct to copy the code from another PR, if there is a better way doing a fix based on a test from another PR - please guide me how to do it.