### PR TITLE
Add ReflectionTypedProperty that doesnt trigger unitialized value error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
 
 install:
-  - rm composer.lock
   - travis_retry composer update -n --prefer-dist
 
 script: ./vendor/bin/phpunit

--- a/lib/Doctrine/Common/Reflection/ReflectionTypedProperty.php
+++ b/lib/Doctrine/Common/Reflection/ReflectionTypedProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Common\Reflection;
+
+use ReflectionProperty;
+
+class ReflectionTypedProperty extends ReflectionProperty
+{
+    public function getValue($object = null)
+    {
+        if (!parent::isInitialized($object)) {
+            return null;
+        }
+
+        return parent::getValue($object);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
     <testsuites>
         <testsuite name="Doctrine Event Manager Test Suite">
             <directory>./tests/Doctrine/</directory>
+            <directory phpVersion="7.4" phpVersionOperator=">=">./tests/Doctrine_PHP74/</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine_PHP74/ReflectionTypedPropertyTest.php
+++ b/tests/Doctrine_PHP74/ReflectionTypedPropertyTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine_PHP74;
+
+use PHPUnit\Framework\TestCase;
+use Doctrine\Common\Reflection\ReflectionTypedProperty;
+
+class ReflectionTypedPropertyTest extends TestCase
+{
+    public function testGetValue() : void
+    {
+        $reflectionProperty = new ReflectionTypedProperty(TypedPropertyClass::class, 'value');
+        $object = new TypedPropertyClass();
+
+        $this->assertNull($reflectionProperty->getValue($object));
+    }
+}
+
+class TypedPropertyClass
+{
+    public int $value;
+}


### PR DESCRIPTION
We need to add checks for if an property is initialized before calling getValue on it, otherwise ORM will throw `Unitialized value` exceptions when hydrating new entities.

To avoid a performance hit for properties that are not typed, we need to avoid checking for typed properties whenever we call `ReflectionProperty::getValue()` by using a subclass that is only used for properties that are:

- typed
- don't have a default value

This PR is one part of a three part fix that will continue in `doctrine/reflection` and will end in `doctrine/orm`.

Next steps:
- Release `doctrine/reflection` 1.1
- Update `doctrine/persistence` 1.2, 1.3 and master to use the new version, and update `RuntimeReflectionService` to create a `ReflectionTypedProperty`
- Update `doctrine/orm` 2.7 and 2.8 to latest `doctrine/persistence` and merge the PR with test fixes https://github.com/doctrine/orm/pull/7857