### PR TITLE
Update of project config for latest version

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -7,11 +7,8 @@
         {
             "name": "1.2",
             "branchName": "master",
-            "slug": "1.2",
-            "upcoming": true,
-            "aliases": [
-                "latest"
-            ]
+            "slug": "latest",
+            "upcoming": true
         },
         {
             "name": "1.1",


### PR DESCRIPTION
Because of a failing website build the config for the latest version was adapted to the same version syntax like in other Doctrine projects.