### PR TITLE
No doc files for distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/docs export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
This PR adds the folder `/docs` in .gitattributes so that it will not be present in distribution