### PR TITLE
[GH-34] Instead of NULL, unitialize typed properties without default.

### DIFF
--- a/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/TypedNoDefaultReflectionProperty.php
@@ -20,4 +20,29 @@ class TypedNoDefaultReflectionProperty extends ReflectionProperty
     {
         return $object !== null && $this->isInitialized($object) ? parent::getValue($object) : null;
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Works around the problem with setting typed no default properties to
+     * NULL which is not supported, instead unset() to uninitialize.
+     *
+     * @link https://github.com/doctrine/orm/issues/7999
+     */
+    public function setValue($object, $value = null)
+    {
+        if ($value === null) {
+            $propertyName = $this->getName();
+
+            $unsetter = function () use ($propertyName) {
+                unset($this->$propertyName);
+            };
+            $unsetter = $unsetter->bindTo($object, $this->getDeclaringClass()->getName());
+            $unsetter();
+
+            return;
+        }
+
+        parent::setValue($object, $value);
+    }
 }

--- a/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests_PHP74/Common/Reflection/TypedNoDefaultReflectionPropertyTest.php
@@ -23,9 +23,32 @@ class TypedNoDefaultReflectionPropertyTest extends TestCase
 
         self::assertNull($reflProperty->getValue($object));
     }
+
+    public function testSetValueNull() : void
+    {
+        $reflection = new TypedNoDefaultReflectionProperty(TypedFoo::class, 'id');
+        $reflection->setAccessible(true);
+
+        $object = new TypedFoo();
+        $object->setId(1);
+
+        $reflection->setValue($object, null);
+
+        self::assertNull($reflection->getValue($object));
+    }
 }
 
 class TypedNoDefaultReflectionPropertyTestClass
 {
     public string $test;
+}
+
+class TypedFoo
+{
+    private int $id;
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
 }


### PR DESCRIPTION
Fixes #34 

Related to doctrine/orm#7999