### PR TITLE
Abandon package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+⚠ This package is abandoned, consider migrating to alternatives, such as
+`roave/better-reflection`. Features that are still useful to Doctrine have been
+moved to `doctrine/persistence`⚠
+
 # Doctrine Reflection
 
 [![Build Status](https://travis-ci.org/doctrine/reflection.svg)](https://travis-ci.org/doctrine/reflection)

--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,6 @@
         "branch-alias": {
             "dev-master": "1.2.x-dev"
         }
-    }
+    },
+    "abandoned": "roave/better-reflection"
 }


### PR DESCRIPTION
Other Doctrine packages have migrated away from `doctrine/reflection`,
which means this library is no longer worth maintaining.

We can still accept PRs from Drupal people for a while to do them a favor, but we should start discouraging people from building on this.